### PR TITLE
add Options.SetAllowConcurrentMemtableWrites() accessor

### DIFF
--- a/options.go
+++ b/options.go
@@ -218,8 +218,19 @@ func (opts *Options) IncreaseParallelism(total_threads int) {
 //
 // Use this if you don't need to keep the data sorted, i.e. you'll never use
 // an iterator, only Put() and Get() API calls
+//
+// If you use this with rocksdb >= 5.0.2, you must call `SetAllowConcurrentMemtableWrites(false)`
+// to avoid an assertion error immediately on opening the db.
 func (opts *Options) OptimizeForPointLookup(block_cache_size_mb uint64) {
 	C.rocksdb_options_optimize_for_point_lookup(opts.c, C.uint64_t(block_cache_size_mb))
+}
+
+// Set whether to allow concurrent memtable writes. Conccurent writes are
+// not supported by all memtable factories (currently only SkipList memtables).
+// As of rocksdb 5.0.2 you must call `SetAllowConcurrentMemtableWrites(false)`
+// if you use `OptimizeForPointLookup`.
+func (opts *Options) SetAllowConcurrentMemtableWrites(allow bool) {
+	C.rocksdb_options_set_allow_concurrent_memtable_write(opts.c, boolToChar(allow))
 }
 
 // OptimizeLevelStyleCompaction optimize the DB for leveld compaction.


### PR DESCRIPTION
The 5.0.2 rocksdb release added an assertion that will throw an exception if the memtable doesn't support concurrent writes but the allow_concurrent_memtable_write is set to its default value of true.

Sadly, if you call Options.OptimizeForPointLookup, it changes the memtable implementation to one that doesn't support concurrent writes, and since gorocksdb doesn't currently expose a setter for allow_concurrent_memtable_write there's no way to use OptimizeForPointLookup without crashing.

This is especially relevant to us because the embedded rocksdb build (from the cockroachdb c-rocksdb) repo just updated to 5.0.2, which is great because it fixed #71.

Anyway, this commit just adds a SetAllowConcurrentMemtableWrites(allow bool) method to the Options struct, and a couple comments to let people know they should use it with OptimizeForPointLookup